### PR TITLE
Use PostScript fonts

### DIFF
--- a/uctest.tex
+++ b/uctest.tex
@@ -21,6 +21,8 @@
 % package geometry should override the various margin settings from .clo and .cls
 % and also eliminates issues where the default papersize is A4
 \usepackage[letterpaper, left=1.5in, right=1.25in, top=1.25in, bottom=1.25in, includefoot]{geometry}
+% Use PostScript fonts as required by UCSC Dissertation Preparation Guidelines
+\usepackage{pslatex}
 
 \begin{document}
 


### PR DESCRIPTION
Current [Dissertation Preparation Guidelines](http://graddiv.ucsc.edu/current-students/pdfs/Diss_Guidelines2012.pdf) requires that fonts should be PostScript Type 1. This pull request make the template conform that requirement.

@adamnovak Please review.
